### PR TITLE
fix(sync): pin pnpm install to --ignore-workspace to avoid dangling ws symlink

### DIFF
--- a/images/sync/Dockerfile
+++ b/images/sync/Dockerfile
@@ -33,9 +33,19 @@ RUN mise trust /src/mise.toml
 
 WORKDIR /src/deps/db-sync
 RUN mise exec -- corepack enable
-RUN --mount=type=cache,target=/root/.local/share/pnpm/store mise exec -- pnpm install --frozen-lockfile
+
+# --ignore-workspace: /src has an ancestor pnpm-workspace.yaml (with
+# shamefully-hoist=true, set for the main logseq app's shadow-cljs builds)
+# that pnpm picks up even though deps/db-sync isn't a declared workspace
+# member. Without this flag, deps/db-sync's dependencies get hoisted and
+# symlinked into /src/node_modules/.pnpm instead of a local store, so
+# copying only deps/db-sync/node_modules below (as this Dockerfile
+# previously did) ships dangling symlinks -- see "Cannot find module 'ws'"
+# crash loop. --ignore-workspace forces a fully self-contained install
+# scoped to deps/db-sync.
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store mise exec -- pnpm install --frozen-lockfile --ignore-workspace
 RUN --mount=type=cache,target=/root/.m2/repository mise exec -- pnpm run build:node-adapter
-RUN CI=true mise exec -- pnpm prune --prod
+RUN CI=true mise exec -- pnpm prune --prod --ignore-workspace
 RUN mkdir -p /tmp/runtime-data
 
 FROM gcr.io/distroless/nodejs24-debian12:nonroot@sha256:14d42e2511532589a7c7e01a753667a74fcc96266e137e8125006b87b0c32d0a


### PR DESCRIPTION
## Problem

`logseq-selfhost-sync:latest` crash-loops on startup:

    Error: Cannot find module 'ws'
    Require stack:
    - /app/worker/dist/node-adapter.js
      code: 'MODULE_NOT_FOUND'

Reproduced against the currently-published commit
`19d88867dc9dd8ec4767131ef411dc8a8e3dc359`
(`ghcr.io/yshalsager/logseq-selfhost-sync:20260707-19d8886`).

## Root cause

`deps/db-sync` isn't a declared workspace member (no `packages:` glob
in `/pnpm-workspace.yaml`), but pnpm still walks up and picks up the
ancestor `pnpm-workspace.yaml` / `.npmrc`, which set
`shamefully-hoist=true` for the main app's shadow-cljs builds. That
hoists db-sync's own dependencies (e.g. `ws`) up into
`/src/node_modules/.pnpm` instead of a store local to `deps/db-sync`.

The Dockerfile's final stage only copies `deps/db-sync/node_modules`,
so any dependency that got hoisted to the workspace root becomes a
dangling symlink in the shipped image:

    /app/node_modules/ws -> ../../../node_modules/.pnpm/ws@8.20.0/node_modules/ws

## Fix

Pass `--ignore-workspace` to both `pnpm install` and `pnpm prune --prod`
in `images/sync/Dockerfile`, so the install is fully self-contained
within `deps/db-sync` regardless of ancestor workspace config.

## Verification

- Built with `LOGSEQ_REF=19d88867dc9dd8ec4767131ef411dc8a8e3dc359`
  (the exact commit behind the broken `:latest` tag).
- `require.resolve('ws')` succeeds inside the built image; the `ws`
  symlink resolves locally within `deps/db-sync/node_modules/.pnpm`.
- Container starts cleanly and logs `Logseq sync listening on port 8787`.
- `images/sync/scripts/smoke-test.sh` passes against the patched image
  and (confirmed) fails against the unpatched `:latest` image with
  "health check failed after 20 retries".
