### PR TITLE
fix(sync): install mldoc explicitly, missing from deps/db-sync/package.json

### DIFF
--- a/images/sync/Dockerfile
+++ b/images/sync/Dockerfile
@@ -44,6 +44,14 @@ RUN mise exec -- corepack enable
 # crash loop. --ignore-workspace forces a fully self-contained install
 # scoped to deps/db-sync.
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store mise exec -- pnpm install --frozen-lockfile --ignore-workspace
+
+# mldoc: node-adapter.js's compiled bundle calls require('mldoc'), but
+# deps/db-sync/package.json doesn't declare it as a dependency (it's only
+# declared in the main logseq/logseq package.json, at ^1.5.9). Without this,
+# the container crash-loops with "Cannot find module 'mldoc'". Installing it
+# explicitly here until upstream adds it to deps/db-sync/package.json.
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store mise exec -- pnpm add mldoc@^1.5.9 --ignore-workspace
+
 RUN --mount=type=cache,target=/root/.m2/repository mise exec -- pnpm run build:node-adapter
 RUN CI=true mise exec -- pnpm prune --prod --ignore-workspace
 RUN mkdir -p /tmp/runtime-data


### PR DESCRIPTION
Pulled `:latest` today and the sync container just crash-loops on boot:

    Error: Cannot find module 'mldoc'
    code: 'MODULE_NOT_FOUND'

Turns out `node-adapter.js`'s compiled bundle calls `require('mldoc')`, but `deps/db-sync/package.json` never lists it as a dependency — it's only in the root `logseq/logseq` package.json (`^1.5.9`). So `pnpm install` inside `deps/db-sync` has no reason to fetch it, and the container ships without it.

Reproduced this against `998207ffd5339386607328d3c71fd190dbf58cb7`, which is what's currently pinned in `UPSTREAM_DB_SYNC_REF`.

This PR just adds `pnpm add mldoc@^1.5.9` as an explicit step in the build stage so it actually lands in the image. It's a stopgap — the real fix is someone adding `mldoc` to `deps/db-sync/package.json` upstream in logseq/logseq, since this'll come back the next time the ref bumps unless that happens.

Verification `require.resolve('mldoc')` succeeds in the built image, container starts successfully, `images/sync/scripts/smoke-test.sh` passes against it and sync server functions correctly
