### PR TITLE
fix(publish): add --ignore-workspace to avoid unstable mldoc hoisting

### DIFF
--- a/images/publish/Dockerfile
+++ b/images/publish/Dockerfile
@@ -33,7 +33,9 @@ RUN mise trust /src/mise.toml
 
 WORKDIR /src/deps/publish
 RUN mise exec -- corepack enable
-RUN --mount=type=cache,target=/root/.local/share/pnpm/store mise exec -- pnpm install --frozen-lockfile
+
+# --ignore-workspace: keep this install self-contained, same as images/sync/Dockerfile.
+RUN --mount=type=cache,target=/root/.local/share/pnpm/store mise exec -- pnpm install --frozen-lockfile --ignore-workspace
 RUN mkdir -p /tmp/publish-runtime-node-modules \
   && cp -a "$(readlink -f node_modules/mldoc)" /tmp/publish-runtime-node-modules/mldoc
 RUN --mount=type=cache,target=/root/.m2/repository mise exec -- pnpm run release


### PR DESCRIPTION
### Problem

The `logseq-selfhost-publish` image build fails during `pnpm install`'s
`mldoc` extraction step:
> cp: cannot stat '': No such file or directory

This happened for a user building locally, and I confirmed it also fails
reliably building against current `logseq/logseq` master
(`ab5709218b8ae51acb055d5e6441cdb519c1f575`).

### Cause
`deps/publish` isn't a declared pnpm workspace member, but it still
inherits the ancestor `pnpm-workspace.yaml`'s `shamefully-hoist=true`
(set for the main logseq app's shadow-cljs builds). This makes whether
`mldoc` lands locally in `deps/publish/node_modules` or gets hoisted up
to `/src/node_modules` unstable across builds/machines. When it hoists,
the existing `cp -a "$(readlink -f node_modules/mldoc)"` step resolves
to nothing and the build fails.

This is the same underlying issue as the earlier `ws` fix in
`images/sync/Dockerfile` (#60), just showing up differently here because
`publish` extracts `mldoc` via an explicit single-package step rather
than copying `node_modules` in bulk.

### Fix
Add `--ignore-workspace` to `deps/publish`'s `pnpm install`, same fix
already merged for `sync`. This keeps the install fully self-contained,
so `mldoc` always resolves at the fixed local path the existing
extraction step assumes.

### Verification
Built and ran successfully against both the currently pinned commit and
current `master`, with `mldoc` landing as a real local directory each
time and `wrangler` serving correctly on startup. Unpatched, the master
build fails consistently with the error above.
