### PR TITLE
feat(sync-worker): allow unscoped tokens for semantic API

### DIFF
--- a/.github/workflows/build-selfhost-sync-worker-image.yml
+++ b/.github/workflows/build-selfhost-sync-worker-image.yml
@@ -18,6 +18,7 @@ on:
       - master
     paths:
       - images/sync-worker/Dockerfile
+      - images/sync-worker/patches/**
       - images/sync-worker/wrangler.selfhost.toml
       - images/sync-worker/scripts/start.sh
       - images/sync/UPSTREAM_DB_SYNC_REF

--- a/images/sync-worker/Dockerfile
+++ b/images/sync-worker/Dockerfile
@@ -37,6 +37,9 @@ RUN mise trust /src/mise.toml
 
 WORKDIR /src/deps/db-sync
 RUN mise exec -- corepack enable
+COPY images/sync-worker/patches /tmp/patches
+RUN git apply --check /tmp/patches/*.patch \
+  && git apply /tmp/patches/*.patch
 RUN --mount=type=cache,target=/root/.local/share/pnpm/store mise exec -- pnpm install --frozen-lockfile --ignore-workspace
 RUN --mount=type=cache,target=/root/.m2/repository mise exec -- pnpm run release
 RUN mise exec -- pnpm run build:api-docs

--- a/images/sync-worker/patches/allow-unscoped-semantic.patch
+++ b/images/sync-worker/patches/allow-unscoped-semantic.patch
@@ -1,0 +1,9 @@
+--- a/deps/db-sync/src/logseq/db_sync/worker/dispatch.cljs
++++ b/deps/db-sync/src/logseq/db_sync/worker/dispatch.cljs
+@@ -86,7 +86,6 @@
+   (p/let [claims (auth/auth-claims request env)]
+     (cond
+       (nil? claims) (http/unauthorized)
+-      (not (contains? (scopes claims) (:scope operation))) (http/error-response "insufficient scope" 403)
+       (= :semantic/graphs-list (:handler operation))
+       (handle-semantic-graphs-list env url claims operation)


### PR DESCRIPTION
Drop the logseq/read|write scope requirement in
handle-semantic-request. Logseq's production Cognito pool never issues those scopes, so the semantic REST + MCP APIs were unreachable for self-hosters pointing the worker at the default pool. Graph-level authorization (JWT validity, issuer, aud, graph membership) is unchanged; rate limiting still applies per sub.